### PR TITLE
When target is empty, dont put &target= in the URI

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -258,8 +258,11 @@
         if (maxdp > 0) {
           extra += "&maxDataPoints=" + maxdp;
         }
-        target = metrics.join('&target=');
-        return graphite_uri + "/render?from=" + from + "&target=" + target + extra;
+        target = '';
+        if (metrics.length) {
+          target += '&target=' + metrics.join('&target=');
+        }
+        return graphite_uri + "/render?from=" + from + target + extra;
       };
       fetchMetricData = function(metrics, from) {
         var options;

--- a/src/composer.coffee
+++ b/src/composer.coffee
@@ -224,8 +224,9 @@ module.exports = class Terphite
       extra += '&format=json' if opts.format == 'json'
       maxdp = parseInt(opts.maxDataPoints,10)
       extra += "&maxDataPoints=#{maxdp}" if maxdp > 0
-      target = metrics.join('&target=')
-      "#{graphite_uri}/render?from=#{from}&target=#{target}#{extra}"
+      target =  ''
+      target += '&target=' + metrics.join('&target=') if metrics.length
+      "#{graphite_uri}/render?from=#{from}#{target}#{extra}"
 
     fetchMetricData = (metrics, from) ->
       options =


### PR DESCRIPTION
Fixes #1 
the version of graphite I used while building this didn't have the problem, but older versions will error  when you call /render?target=
